### PR TITLE
Remove leftover debug calls in configReader

### DIFF
--- a/configReader.py
+++ b/configReader.py
@@ -86,11 +86,3 @@ class Configuration():
             newadmins.append(admin)
         
         return admins
-
-
-conf = Configuration()
-print conf.doesExist()
-#conf.createNewConfig()
-print conf.doesExist()
-conf.loadConfig()
-print conf.getChannels()


### PR DESCRIPTION
Fixes exception at start when config.txt doesn't exist.
